### PR TITLE
Remove cluster shard actor and coordinator actor after removing schema.

### DIFF
--- a/src/main/scala/wandou/astore/package.scala
+++ b/src/main/scala/wandou/astore/package.scala
@@ -1,5 +1,6 @@
 package wandou
 
+import org.apache.avro.Schema
 import org.apache.avro.generic.GenericData.Record
 import scala.concurrent.duration.Duration
 

--- a/src/main/scala/wandou/astore/serializer/AvroMarshaler.scala
+++ b/src/main/scala/wandou/astore/serializer/AvroMarshaler.scala
@@ -1,0 +1,91 @@
+package wandou.astore.serializer
+
+import java.nio.ByteOrder
+
+import akka.util.ByteString
+import org.apache.avro.Schema
+import wandou.astore.UpdatedFields
+import wandou.avro
+
+import scala.collection.JavaConversions._
+import scala.util.{ Failure, Success }
+
+class AvroMarshaler(val schema: Schema) {
+
+  implicit val byteOrder = ByteOrder.BIG_ENDIAN
+
+  val fieldPosToSchemaMap = schema.getFields.map { field =>
+    field.pos() -> field.schema()
+  }.toMap
+
+  def marshal(avroData: Any) = {
+    AvroMarshaler.marshal(avroData, schema)
+  }
+
+  def unmarshal(avroBytes: Array[Byte]) = {
+    AvroMarshaler.unmarshal(avroBytes, schema)
+  }
+
+  def marshalField(pos: Int, value: Any) = {
+    val builder = ByteString.newBuilder
+    builder.putInt(pos)
+    val fieldSchema = fieldPosToSchemaMap(pos)
+    val valueMarshaled = AvroMarshaler.marshal(value, fieldSchema)
+    builder.putInt(valueMarshaled.length)
+    builder.putBytes(valueMarshaled)
+    builder.result().toArray
+  }
+
+  def marshalFields(fields: List[(Int, Any)]): Array[Byte] = {
+    val builder = ByteString.newBuilder
+    builder.putInt(fields.size)
+    builder.putBytes(
+      fields.flatMap { field =>
+        marshalField(field._1, field._2)
+      }.toArray)
+    builder.result().toArray
+  }
+
+  def marshalFields(fields: UpdatedFields): Array[Byte] = {
+    marshalFields(fields.updatedFields)
+  }
+
+  def unmarshalField(avroBytes: Array[Byte]) = {
+    val bytes = ByteString(avroBytes).iterator
+    val pos = bytes.getInt
+    val length = bytes.getInt
+    val payload = Array.ofDim[Byte](length)
+    bytes.getBytes(payload)
+    val value = AvroMarshaler.unmarshal(payload, fieldPosToSchemaMap(pos))
+    (pos, value)
+  }
+
+  def unmarshalFields(avroBytes: Array[Byte]): List[(Int, Any)] = {
+    val bytes = ByteString(avroBytes).iterator
+    val size = bytes.getInt
+    (1 to size) map { i =>
+      val pos = bytes.getInt
+      val length = bytes.getInt
+      val payload = Array.ofDim[Byte](length)
+      bytes.getBytes(payload)
+      val value = AvroMarshaler.unmarshal(payload, fieldPosToSchemaMap(pos))
+      (pos, value)
+    } toList
+  }
+}
+
+object AvroMarshaler {
+  def marshal(avroData: Any, schema: Schema) = {
+    avro.avroEncode(avroData, schema) match {
+      case Success(x)  => x
+      case Failure(ex) => throw ex
+    }
+  }
+
+  def unmarshal(avroBytes: Array[Byte], schema: Schema) = {
+    avro.avroDecode[Any](avroBytes, schema) match {
+      case Success(x)  => x
+      case Failure(ex) => throw ex
+    }
+  }
+}


### PR DESCRIPTION
Remove cluster shard actor and coordinator actor after removing corresponding schema.

Not persist schema when persist avro data, since schema may be changed.
It also saves space.

Use concurrent hash map instead of lock-based map.